### PR TITLE
Fixed drops

### DIFF
--- a/src/onebone/artificialintelligent/entity/Cow.php
+++ b/src/onebone/artificialintelligent/entity/Cow.php
@@ -62,6 +62,7 @@ class Cow extends BaseEntity implements MovingEntity{
 
   public function getDrops(){
     return [
+      Item::get(Item::LEATHER, 0, mt_rand(0, 2));
       Item::get(Item::RAW_BEEF, 0, mt_rand(1, 3))
     ];
   }

--- a/src/onebone/artificialintelligent/entity/Sheep.php
+++ b/src/onebone/artificialintelligent/entity/Sheep.php
@@ -80,7 +80,7 @@ class Sheep extends BaseEntity implements MovingEntity{
 
   public function getDrops(){
     return [
-      Item::get(Item::WOOL, 0, mt_rand(1, 3))
+      Item::get(Item::WOOL, 0, 1)
     ];
   }
 }


### PR DESCRIPTION
A cow can actually drop 0-2 leathers when killed, and sheeps only drop 1 wool block when killed, unless they're sheared, which yields 1-3 wool blocks.
